### PR TITLE
Improve dependency declaractions

### DIFF
--- a/.github/workflows/scheduled-release-ci.yaml
+++ b/.github/workflows/scheduled-release-ci.yaml
@@ -1,16 +1,17 @@
-name: Release Java CI
+name: Scheduled Release Java CI
 
 on:
-  push:
-    branches:
-      - main
-      - 'release/**'
+  # Nightly builds to ensure dependencies don't break anything
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: main
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Build Status](https://github.com/cryptimeleon/predenc/workflows/Development%20Java%20CI/badge.svg)
 ![Build Status](https://github.com/cryptimeleon/predenc/workflows/Release%20Java%20CI/badge.svg)
+![Build Status](https://github.com/cryptimeleon/predenc/workflows/Scheduled%20Release%20Java%20CI/badge.svg)
 # Predenc
 
 The Cryptimeleon Predenc project contains various predicate encryption implementations such as attribute-based encryption or identity-based encryption.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 group 'org.cryptimeleon'
 archivesBaseName = project.name
 boolean isRelease = project.hasProperty("release")
-version = '1.0.1'  + (isRelease ? "" : "-SNAPSHOT")
+version = '1.1.0'  + (isRelease ? "" : "-SNAPSHOT")
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -30,9 +30,7 @@ dependencies {
     def cracoVersion = cracoVersionNoSuffix + (isRelease ? "" : "-SNAPSHOT")
     def mathVersion = mathVersionNoSuffix + (isRelease ? "" : "-SNAPSHOT")
 
-    implementation group: 'org.cryptimeleon', name: 'craco', version: cracoVersion
-    implementation group: 'org.cryptimeleon', name: 'math', version: mathVersion
-
+    api group: 'org.cryptimeleon', name: 'craco', version: cracoVersion
 
     // For using craco tests on the schemes
     testImplementation(group: 'org.cryptimeleon', name: 'craco', version: cracoVersion) {
@@ -80,9 +78,11 @@ test {
 task javadocLatex(type: Javadoc) {
     source = sourceSets.main.allJava
     classpath = sourceSets.main.runtimeClasspath
-    // link to math and craco javadocs
-    options {
-        links "https://javadoc.io/doc/org.cryptimeleon/math/" + mathVersionNoSuffix, "https://javadoc.io/doc/org.cryptimeleon/craco/" + cracoVersionNoSuffix
+    if (isRelease) {
+        // link to math and craco javadocs
+        options {
+            links "https://javadoc.io/doc/org.cryptimeleon/math/" + mathVersionNoSuffix, "https://javadoc.io/doc/org.cryptimeleon/craco/" + cracoVersionNoSuffix
+        }
     }
     // enable latex rendering via mathjax
     options.addBooleanOption("-allow-script-in-comments", true)


### PR DESCRIPTION
This fixes #21 .
Also increments version to 1.1.0 as it adds additional APIs (those from Math and Craco.

Without this, when using Predenc as a dependency, you have to basically add Craco as a dependency, else important types such as `EncryptionKey` won't be accessible.