### PR TITLE
Adjust code to only use asInteger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Made Craco an api dependency such that its API can be used. Removed Math dependency as it is now unnecessary.
+- Made Craco an api dependency such that its API can be used. Removed Math dependency as it is now unnecessary
+- Update Craco dependency to version 3.0.0
 
 ## [1.0.0] - 2021-03-05
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 group 'org.cryptimeleon'
 archivesBaseName = project.name
 boolean isRelease = project.hasProperty("release")
-version = '1.1.0'  + (isRelease ? "" : "-SNAPSHOT")
+version = '2.0.0'  + (isRelease ? "" : "-SNAPSHOT")
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -22,8 +22,8 @@ repositories {
     jcenter()
 }
 
-def mathVersionNoSuffix = '2.0.0'
-def cracoVersionNoSuffix = '1.1.0'
+def mathVersionNoSuffix = '3.0.0'
+def cracoVersionNoSuffix = '3.0.0'
 
 dependencies {
 

--- a/src/main/java/org/cryptimeleon/predenc/WatersHash.java
+++ b/src/main/java/org/cryptimeleon/predenc/WatersHash.java
@@ -52,7 +52,7 @@ public class WatersHash implements HashIntoGroup {
         for (int i = 1; i <= T.size(); ++i) {
             knownPoints.put(BigInteger.valueOf(i), T.get(i-1));
         }
-        return LagrangeUtils.interpolateInTheExponent(knownPoints, baseHash.hash(x).getInteger());
+        return LagrangeUtils.interpolateInTheExponent(knownPoints, baseHash.hash(x).asInteger());
     }
 
     public List<GroupElement> getT() {

--- a/src/main/java/org/cryptimeleon/predenc/abe/cp/small/ABECPWat11Small.java
+++ b/src/main/java/org/cryptimeleon/predenc/abe/cp/small/ABECPWat11Small.java
@@ -175,7 +175,7 @@ public class ABECPWat11Small implements PredicateEncryptionScheme {
             // the party linked to this share
             Attribute rhoI = (Attribute) msp.getShareReceiver(omegaI.getKey());
 
-            if (!omegaI.getValue().getInteger().equals(BigInteger.ZERO)) {
+            if (!omegaI.getValue().asInteger().equals(BigInteger.ZERO)) {
                 GroupElement cI = c.getMapC().get(i);
                 GroupElement dI = c.getMapD().get(i);
                 GroupElement kRhoI = mapK.get(rhoI);
@@ -188,7 +188,7 @@ public class ABECPWat11Small implements PredicateEncryptionScheme {
                 // e(C_i, L) \cdot e(D_i, K_{\rho(i)}
                 map1 = map1.op(map2);
                 // (e(C_i, L) \cdot e(D_i, K_{\rho(i)})^{\omega_i}
-                map1 = map1.pow(omegaI.getValue().getInteger());
+                map1 = map1.pow(omegaI.getValue().asInteger());
                 productList.add(map1);
             }
         }

--- a/src/main/java/org/cryptimeleon/predenc/abe/cp/small/asymmetric/ABECPWat11AsymSmall.java
+++ b/src/main/java/org/cryptimeleon/predenc/abe/cp/small/asymmetric/ABECPWat11AsymSmall.java
@@ -132,7 +132,7 @@ public class ABECPWat11AsymSmall implements PredicateEncryptionScheme {
             // the party linked to this share
             Attribute rhoI = (Attribute) msp.getShareReceiver(omegaI.getKey());
 
-            if (!omegaI.getValue().getInteger().equals(BigInteger.ZERO)) {
+            if (!omegaI.getValue().asInteger().equals(BigInteger.ZERO)) {
                 GroupElement cElementI = c.getMapC().get(i);
                 GroupElement dElementI = c.getMapD().get(i);
                 GroupElement kElementRhoI = sk.getMapKx().get(rhoI);
@@ -141,7 +141,7 @@ public class ABECPWat11AsymSmall implements PredicateEncryptionScheme {
                 GroupElement map2 = pp.getE().apply(kElementRhoI, dElementI);
 
                 map1 = map1.op(map2);
-                map1 = map1.pow(omegaI.getValue().getInteger());
+                map1 = map1.pow(omegaI.getValue().asInteger());
                 zList.add(map1);
             }
         }

--- a/src/main/java/org/cryptimeleon/predenc/abe/fuzzy/small/IBEFuzzySW05Small.java
+++ b/src/main/java/org/cryptimeleon/predenc/abe/fuzzy/small/IBEFuzzySW05Small.java
@@ -146,7 +146,7 @@ public class IBEFuzzySW05Small implements PredicateEncryptionScheme {
                 // the attribute of this row number
                 Attribute rho_i = (Attribute) msp.getShareReceiver(a.getKey());
                 // the result of alpha * row_i = S_i
-                BigInteger alpha = a.getValue().getInteger();
+                BigInteger alpha = a.getValue().asInteger();
                 if (!alpha.equals(BigInteger.ZERO)) {
                     tmp = tmp.op(pp.getE().apply(d.get(i), ct.getE().get(rho_i).pow(alpha)));
                 }
@@ -248,7 +248,7 @@ public class IBEFuzzySW05Small implements PredicateEncryptionScheme {
                 // M_i_u = M_i_u / t_p_i
                 m_i_u = (ZpElement) m_i_u.div(t_p_i);
                 // D_i = g^M_i_u
-                d.put(BigInteger.valueOf(i), pp.getG().pow(m_i_u.getInteger()).compute());
+                d.put(BigInteger.valueOf(i), pp.getG().pow(m_i_u.asInteger()).compute());
             }
         } catch (NullPointerException e) {
             throw new WrongAccessStructureException("The attributes provided in the identity are not in the universe.");

--- a/src/main/java/org/cryptimeleon/predenc/abe/kp/large/AbstractABEKPGPSW06.java
+++ b/src/main/java/org/cryptimeleon/predenc/abe/kp/large/AbstractABEKPGPSW06.java
@@ -188,7 +188,7 @@ public class AbstractABEKPGPSW06 {
         // the terms would be 1 anyway.
         Supplier<Stream<Map.Entry<Integer, Zp.ZpElement>>> nonZeroSVElements = () ->
                 solvingVector.entrySet().parallelStream()
-                        .filter(elem -> !value.apply(elem).getInteger().equals(BigInteger.ZERO));
+                        .filter(elem -> !value.apply(elem).asInteger().equals(BigInteger.ZERO));
 
         // \prod_{i \in \omega} e(R_i^{-w_i}, E_{\rho(i)})
         GroupElement factor1 = nonZeroSVElements.get()

--- a/src/main/java/org/cryptimeleon/predenc/kem/abe/cp/os/ElgamalLargeUniverseDelegationKEM.java
+++ b/src/main/java/org/cryptimeleon/predenc/kem/abe/cp/os/ElgamalLargeUniverseDelegationKEM.java
@@ -276,7 +276,7 @@ public class ElgamalLargeUniverseDelegationKEM
         /*get blinding for ElGamal private key*/
         ZnElement z = zp.getUniformlyRandomElement();
 
-        return generateTransformationKey(original, z.getInteger());
+        return generateTransformationKey(original, z.asInteger());
     }
 
     public TransformationAndDecryptionKey generateTransformationKey(


### PR DESCRIPTION
Also adjust build config to use Math version 3.0.0 and Craco version 3.0.0. Predenc version is incremented to version 2.0.0 as Math changes are exported as public API and therefore also imply an API-breaking change.